### PR TITLE
fix(release): pin semantic-release-config to stable working version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,4 +30,4 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           extra-plugins: |
-            @open-turo/semantic-release-config
+            @open-turo/semantic-release-config@^1.4.0


### PR DESCRIPTION
**Description**

- Pins semantic-release-version to known stable version to allow release to pass. 

**Changes**

- fix(release): pin semantic-release-config to stable working version ([548d951](https://github.com/open-turo/actions-security/commit/b6ece7e6e4a7c62041eb38dfe4130d2b7ffc4fb9))