### PR TITLE
fix(semgrep): pause semgrep checks

### DIFF
--- a/static-analysis/semgrep/action.yaml
+++ b/static-analysis/semgrep/action.yaml
@@ -5,10 +5,14 @@ inputs:
     required: true
     description: SemGrep API token to be added to repo that allows to pull latest rule config from ruleboard in Semgrep UI
 runs:
-  using: docker
-  image: docker://returntocorp/semgrep
-  args:
-    - semgrep
-    - ci
-  env:
-    SEMGREP_APP_TOKEN: ${{ inputs.semgrep-app-token }}
+  using: composite
+  steps:
+    - run: echo "pausing checks"
+      shell: bash
+#  using: docker
+#  image: docker://returntocorp/semgrep
+#  args:
+#    - semgrep
+#    - ci
+#  env:
+#    SEMGREP_APP_TOKEN: ${{ inputs.semgrep-app-token }}


### PR DESCRIPTION
**Description**

This pauses direct calls to semgrep because it's setting files to root ownership.

The semgrep action is setting file content ownership to `root`, this breaks other GHA runs.

**Changes**

* fix(semgrep): pause semgrep checks

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
