### PR TITLE
skip update dependencies job

### DIFF
--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -17,6 +17,8 @@ jobs:
   update-dependencies:
     runs-on: ubuntu-latest
     name: Update dependencies
+    # TODO: remove skip when this workflow is resumed in other actions
+    if: false
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Skip update dependencies job until its fixed on other `open-turo/actions-*` repos