### PR TITLE
feat(container-scan): add build docker image

### DIFF
--- a/container-scan/README.md
+++ b/container-scan/README.md
@@ -16,6 +16,8 @@ To use this action in your GitHub Actions workflow, include the following steps:
 - name: Lacework Container Scan
   uses: open-turo/actions-security/container-scan@v1 # Specify the path to the action in your repository
   with:
+    dockerhub-user: ${{ secrets.DOCKER_USERNAME }}
+    dockerhub-password: ${{ secrets.DOCKER_PASSWORD }}
     lw-account-name: ${{ secrets.LW_ACCOUNT_NAME }}
     lw-access-token: ${{ secrets.LW_ACCESS_TOKEN }}
     github-token: <your-secret-for-github-token>
@@ -28,11 +30,18 @@ To use this action in your GitHub Actions workflow, include the following steps:
 
 | parameter | description | required | default |
 | --- | --- | --- | --- |
+| dockerhub-user | username for dockerhub | `false` |  |
+| dockerhub-password | password for dockerhub | `false` |  |
 | docker-config-file | Path to the docker config file (defaults to .docker-config.json) Must contain imageName, may contain dockerfile | `false` | .docker-config.json |
 | github-token | GitHub token | `true` |  |
 | lw-account-name | Lacework account name | `true` |  |
 | lw-access-token | Lacework access token | `true` |  |
+| image-name | Docker image name | `false` |  |
 | image-tag | Docker image tag | `true` |  |
+| image-platform | Target platform to build image for (eg. linux/amd64 (default), linux/arm64, etc) | `false` | linux/amd64 |
+| build-args | List of build arguments for docker build as key-value pairs (e.g., KEY=VALUE) | `false` |  |
+| secrets | List of secrets for docker build as key-value pairs (e.g., SECRET_KEY=VALUE) | `false` |  |
+| enable-docker-build | Docker image tag | `false` | true |
 <!-- action-docs-inputs -->
 
 <!-- action-docs-outputs -->
@@ -41,7 +50,6 @@ To use this action in your GitHub Actions workflow, include the following steps:
 | parameter | description |
 | --- | --- |
 | comment-id | Comment ID of the test report |
-| image-name | Docker image name |
 <!-- action-docs-outputs -->
 
 <!-- action-docs-runs -->
@@ -78,8 +86,11 @@ jobs:
       - name: Lacework Container Scan
         uses: open-turo/actions-security/container-scan@v1 # Specify the path to the action in your repository
         with:
+          dockerhub-user: ${{ secrets.DOCKER_USERNAME }}
+          dockerhub-password: ${{ secrets.DOCKER_PASSWORD }}
           lw-account-name: ${{ secrets.LW_ACCOUNT_NAME }}
           lw-access-token: ${{ secrets.LW_ACCESS_TOKEN }}
+          github-token: <your-secret-for-github-token>
           image-tag: <your-docker-image-tag>
 ```
 

--- a/container-scan/action.yaml
+++ b/container-scan/action.yaml
@@ -2,6 +2,14 @@ name: "Security Scan Composite Action"
 description: "GitHub Action for scanning container image for vulnerabilities using Lacework"
 
 inputs:
+  dockerhub-user:
+    required: false
+    default: ""
+    description: username for dockerhub
+  dockerhub-password:
+    required: false
+    default: ""
+    description: password for dockerhub
   docker-config-file:
     required: false
     description: Path to the docker config file (defaults to .docker-config.json) Must contain imageName, may contain dockerfile
@@ -15,17 +23,34 @@ inputs:
   lw-access-token:
     required: true
     description: Lacework access token
+  image-name:
+    required: false
+    description: Docker image name
   image-tag:
     required: true
+    description: Docker image tag
+  image-platform:
+    description: Target platform to build image for (eg. linux/amd64 (default), linux/arm64, etc)
+    required: false
+    default: linux/amd64
+
+  build-args:
+    required: false
+    description: List of build arguments for docker build as key-value pairs (e.g., KEY=VALUE)
+    default: ""
+  secrets:
+    required: false
+    description: List of secrets for docker build as key-value pairs (e.g., SECRET_KEY=VALUE)
+    default: ""
+  enable-docker-build:
+    required: false
+    default: true
     description: Docker image tag
 
 outputs:
   comment-id:
     description: Comment ID of the test report
     value: ${{ steps.comment-pr.outputs.comment-id }}
-  image-name:
-    description: Docker image name
-    value: ${{ steps.config.outputs.image-name }}
 
 runs:
   using: composite
@@ -33,32 +58,62 @@ runs:
     - name: Checkout Repository
       uses: actions/checkout@v4
 
-    - name: Extract docker image name
-      id: config
+    - name: Build docker image
+      if: ${{ inputs.enable-docker-build }}
+      uses: open-turo/actions-security/build-docker@v2
+      id: build-docker
+      with:
+        dockerhub-user: ${{ inputs.dockerhub-user }}
+        dockerhub-password: ${{ inputs.dockerhub-password }}
+        github-token: ${{ inputs.github-token }}
+        image-version: ${{ inputs.image-tag }}
+        image-platform: ${{ inputs.image-platform }}
+        load: true
+        push: false
+        docker-metadata-tags: |
+          type=ref,event=branch
+          type=ref,event=pr
+        build-args: ${{ inputs.build-args }}
+        secrets: ${{ inputs.secrets }}
+
+    - name: "Determining image name"
       shell: bash
-      run: | # if docker-config file does not exist - fail
-        if [ ! -f "${{ inputs.docker-config-file }}" ]; then
-          echo "::error::Docker config file not found: ${{ inputs.docker-config-file }}" && exit 1
+      id: set_image_name
+      run: |
+        if [ "${{ inputs.enable-docker-build }}" == "true" ]; then
+          echo "::set-output name=image_name::${{ steps.build-docker.outputs.image-name }}"
+        else
+          echo "::set-output name=image_name::${{ inputs.image-name }}"
         fi
-        image_name=$(jq -r .imageName ${{ inputs.docker-config-file }})
-        echo "image-name: ${image_name}"
-        echo "image-name=${image_name}" >> $GITHUB_OUTPUT
 
     - name: Scan container image for vulnerabilities using Lacework
       uses: lacework/lw-scanner-action@v1.4.1
       with:
         LW_ACCOUNT_NAME: ${{ inputs.lw-account-name }}
         LW_ACCESS_TOKEN: ${{ inputs.lw-access-token }}
-        IMAGE_NAME: ${{ steps.config.outputs.image-name }}
+        IMAGE_NAME: ${{ steps.set_image_name.outputs.image_name }}
         IMAGE_TAG: ${{ inputs.image-tag }}
         SAVE_RESULTS_IN_LACEWORK: true
         RESULTS_IN_GITHUB_SUMMARY: true
         PRETTY_OUTPUT: true
 
+    - name: Check if Lacework scan results file exist
+      id: check-results
+      run: |
+        if [ -f results.stdout ]; then
+          echo "Scan results file (results.stdout) exists"
+          exit 0
+        else
+          echo "Scan results file (results.stdout) does not exist"
+          exit 1
+        fi
+      shell: bash
+
     - name: Change formatting for PR
       if: always()
       run: |
-        echo "<details><summary>Lacework Inline Scanner Results</summary>" > pr-results.md
+        echo "## Lacework Inline Scanner Results" > pr-results.md
+        echo "<details><summary>Click to expand</summary>" >> pr-results.md
         echo "<pre>" >> pr-results.md
         cat results.stdout >> pr-results.md
         echo "</pre>" >> pr-results.md
@@ -67,15 +122,15 @@ runs:
 
     - name: Check for previous report comment
       id: fc
-      if: github.event.pull_request.number != ''
-      uses: peter-evans/find-comment@v1
+      if: github.event_name == 'pull_request' && github.event.pull_request.number != ''
+      uses: peter-evans/find-comment@v3
       with:
         issue-number: ${{ github.event.pull_request.number }}
         comment-author: "github-actions[bot]"
-        body-includes: "<!-- lacework inline scanner results comment -->"
+        body-includes: "Lacework Inline Scanner Results"
 
     - name: Delete previous test report comment
-      if: steps.fc.outputs.comment-id != ''
+      if: github.event_name == 'pull_request' && steps.fc.outputs.comment-id != ''
       uses: winterjung/comment@v1
       with:
         type: delete
@@ -83,13 +138,15 @@ runs:
         token: ${{ inputs.github-token }}
 
     - name: Comment PR
-      if: always()
+      if: github.event_name == 'pull_request'
       uses: thollander/actions-comment-pull-request@v2
       with:
         filePath: pr-results.md
+        mode: recreate
+        comment_tag: to_recreate
 
     - name: Cleanup docker image
       if: always()
       run: |
-        docker image rm ${{ steps.config.outputs.image-name }}:${{ inputs.image-tag }}
+        docker image rm ${{ steps.build-docker.outputs.image-name }}:${{ inputs.image-tag }}
       shell: bash

--- a/docker-build/README.md
+++ b/docker-build/README.md
@@ -1,0 +1,113 @@
+# GitHub Action Docker-build
+
+<!-- prettier-ignore-start -->
+<!-- action-docs-description -->
+## Description
+
+Only builds docker images for the input platform, tags and image version
+<!-- action-docs-description -->
+<!-- prettier-ignore-end -->
+
+<!-- prettier-ignore-start -->
+## Usage
+
+This action will build a docker image with appropriate tags.
+
+It assumes that the repo has a configuration file in `<repo-root>/.docker-config.json` with the following properties:
+
+- `imageName`: the image name (org/image-name)
+- `dockerfile`: the path to the dockerfile to build - defaults to `./Dockerfile`
+
+Example:
+
+```json
+{
+  "imageName": "turo/hello-world-msvc",
+  "dockerfile": "./Dockerfile"
+}
+```
+
+#### Basic Usage:
+
+```yaml
+steps:
+  - uses: open-turo/actions-jvm/release@v3
+    name: Release
+    id: release
+    with:
+      checkout-repo: true
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+      dry-run: false
+  - uses: open-turo/actions-security/build-docker@v2
+    id: docker-build
+    with:
+      dockerhub-user: ${{ secrets.DOCKER_USERNAME }}
+      dockerhub-password: ${{ secrets.DOCKER_PASSWORD }}
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+      image-version: ${{ steps.release.outputs.new-release-version }}
+      docker-metadata-tags: |
+        type=ref,event=branch
+        type=ref,event=pr
+        type=semver,pattern={{version}},value=${{ steps.release.outputs.new-release-version }}
+```
+
+#### Dynamically input multiple build arguments and secrets:
+
+If you want to pass multiple build arguments and secrets, you can use the `build-args` and `secrets` input parameters.
+
+```yaml
+steps:
+  - uses: open-turo/actions-jvm/release@v3
+    name: Release
+    id: release
+    with:
+      checkout-repo: true
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+      dry-run: false
+  - uses: open-turo/actions-security/build-docker@v2
+    id: docker-build
+    with:
+      dockerhub-user: ${{ secrets.DOCKER_USERNAME }}
+      dockerhub-password: ${{ secrets.DOCKER_PASSWORD }}
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+      image-version: ${{ steps.release.outputs.new-release-version }}
+      build-args: |
+        KEY1=VALUE1
+        KEY2=VALUE2
+      secrets: |
+        SECRET_KEY1=SECRET_VALUE1
+        SECRET_KEY2=SECRET_VALUE2
+      docker-metadata-tags: |
+        type=ref,event=branch
+        type=ref,event=pr
+        type=semver,pattern={{version}},value=${{ steps.release.outputs.new-release-version }}
+```
+<!-- prettier-ignore-end -->
+
+## Inputs
+
+| parameter            | description                                                                                                      | required | default             |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------- | -------- | ------------------- |
+| docker-config-file   | Path to the docker config file (defaults to .docker-config.json) Must contain imageName, may contain dockerfile. | `false`  | .docker-config.json |
+| dockerhub-user       | username for dockerhub                                                                                           | `true`   |                     |
+| dockerhub-password   | password for dockerhub                                                                                           | `true`   |                     |
+| github-token         | Usually secrets.GITHUB_TOKEN                                                                                     | `true`   |                     |
+| image-version        | Docker image version                                                                                             | `true`   |                     |
+| image-platform       | Target platform to build image for (eg. linux/amd64 (default), linux/arm64, etc)                                 | `false`  | linux/amd64         |
+| docker-metadata-tags | 'List of tags as key-value pair attributes' See: https://github.com/docker/metadata-action#tags-input            | `false`  |                     |
+| push                 | Do you want to push the image to the registry                                                                    | `false`  | false               |
+| load                 | Do you want to load the single-platform build result to docker images                                            | `false`  | true                |
+| build-args           | List of build arguments as key-value pairs (e.g., KEY=VALUE)                                                     | `false`  |                     |
+| secrets              | List of secrets as key-value pairs (e.g., SECRET_KEY=VALUE)                                                      | `false`  |                     |
+
+## Outputs
+
+| parameter      | description                                        |
+| -------------- | -------------------------------------------------- |
+| image-name     | Docker image name                                  |
+| image-with-tag | Full image with tag - <image-name>:<image-version> |
+| image-tag      | Docker image tag                                   |
+
+## Runs
+
+This action is a `composite` action.

--- a/docker-build/action.yaml
+++ b/docker-build/action.yaml
@@ -1,0 +1,117 @@
+name: Build docker images
+description: Only builds docker images for the input platform, tags and image version
+
+inputs:
+  docker-config-file:
+    required: false
+    description: Path to the docker config file (defaults to .docker-config.json) Must contain imageName, may contain dockerfile.
+    default: .docker-config.json
+  dockerhub-user:
+    required: true
+    description: username for dockerhub
+  dockerhub-password:
+    required: true
+    description: password for dockerhub
+  github-token:
+    required: true
+    description: Usually secrets.GITHUB_TOKEN
+  image-version:
+    required: true
+    description: Docker image version
+  image-platform:
+    description: Target platform to build image for (eg. linux/amd64 (default), linux/arm64, etc)
+    required: false
+    default: linux/amd64
+  docker-metadata-tags:
+    description: "'List of tags as key-value pair attributes' See: https://github.com/docker/metadata-action#tags-input"
+    required: false
+  push:
+    required: false
+    default: false
+    description: Do you want to push the image to the registry
+  load:
+    required: false
+    default: true
+    description: Do you want to load the single-platform build result to docker images
+  build-args:
+    required: false
+    description: List of build arguments as key-value pairs (e.g., KEY=VALUE)
+    default: ""
+  secrets:
+    required: false
+    description: List of secrets as key-value pairs (e.g., SECRET_KEY=VALUE)
+    default: ""
+outputs:
+  image-name:
+    description: Docker image name
+    value: ${{ steps.config.outputs.image-name }}
+  image-with-tag:
+    description: Full image with tag - <image-name>:<image-version>
+    value: ${{ steps.config.outputs.image-name }}:${{ inputs.image-version }}
+  image-tag:
+    description: Docker image tag
+    value: ${{ inputs.image-version }}
+
+runs:
+  using: composite
+  steps:
+    - name: Dump GitHub context
+      shell: bash
+      env:
+        GITHUB_CONTEXT: ${{ toJson(github) }}
+      run: echo "$GITHUB_CONTEXT"
+    - id: config
+      shell: bash
+      run: |
+        # if docker-config file does not exist - fail
+        if [ ! -f "${{ inputs.docker-config-file }}" ]; then
+          echo "::error::Docker config file not found: ${{ inputs.docker-config-file }}" && exit 1
+        fi
+        image_name=$(jq -r .imageName ${{ inputs.docker-config-file }})
+        echo "image-name: ${image_name}"
+        echo "image-name=${image_name}" >> $GITHUB_OUTPUT
+        dockerfile=$(jq -r '.dockerfile // "./Dockerfile"' ${{ inputs.docker-config-file }})
+        echo "Dockerfile: ${dockerfile}"
+        echo "dockerfile=${dockerfile}" >> $GITHUB_OUTPUT
+        echo "image-version: ${{ inputs.image-version }}"
+        echo "image-platform: ${{ inputs.image-platform }}"
+        echo "docker-metadata-tags: ${{ inputs.docker-metadata-tags }}"
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ inputs.dockerhub-user }}
+        password: ${{ inputs.dockerhub-password }}
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: |
+          ${{ steps.config.outputs.image-name }}
+        flavor: |
+          latest=false
+        tags: |
+          ${{ inputs.image-tags }}
+    - name: Build and push
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        platforms: ${{ inputs.image-platform }}
+        file: ${{ steps.config.outputs.dockerfile }}
+        build-args: |
+          GIT_COMMIT=${{ github.sha }}
+          GITHUB_TOKEN=${{ inputs.github-token }}
+          BUILDTIME=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
+          VERSION=${{ inputs.image-version }}
+          REVISION=${{ inputs.image-version }}
+          BRANCH=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.branch'] }}
+          ${{ inputs.build-args }}
+        push: ${{ inputs.push }}
+        load: ${{ inputs.load }}
+        tags: ${{ steps.config.outputs.image-name }}:${{ inputs.image-version }}
+        labels: ${{ steps.meta.outputs.labels }}
+        secrets: |
+          ${{ inputs.secrets }}


### PR DESCRIPTION
**Description**

New additions:

- Container-scan composite action will now have option to build docker image for scan.
- Adds new composite action to build docker image

Note: Build docker image step will not push image to registry

It also fixes the following:
- Format the comment message
- Recreate the comment message for multiple builds

**Changes**

* feat(container-scan): add build docker image

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
