### PR TITLE
chore(container-scan): replace cat with tail to generate scan results

### DIFF
--- a/container-scan/action.yaml
+++ b/container-scan/action.yaml
@@ -115,7 +115,7 @@ runs:
         echo "## Lacework Inline Scanner Results" > pr-results.md
         echo "<details><summary>Click to expand</summary>" >> pr-results.md
         echo "<pre>" >> pr-results.md
-        cat results.stdout >> pr-results.md
+        tail -n +1 results.stdout >> pr-results.md
         echo "</pre>" >> pr-results.md
         echo "</details>" >> pr-results.md
       shell: bash


### PR DESCRIPTION
Use tail instead of cat to display scan results