### PR TITLE
fix(semgrep): unpause semgrep checks for v2 sec2259

### DIFF
--- a/static-analysis/semgrep/action.yaml
+++ b/static-analysis/semgrep/action.yaml
@@ -14,14 +14,13 @@ runs:
     - name: Checkout
       if: ${{inputs.checkout-repo == 'true'}}
       uses: actions/checkout@v4
-    - run: echo "pausing checks"
+    - run: |
+        docker run --rm -v  "${PWD}:/src" \
+        -e SEMGREP_APP_TOKEN=${{ inputs.semgrep-app-token }} \
+        -e SEMGREP_REPO_NAME=${GITHUB_REPOSITORY} \
+        -e SEMGREP_BRANCH=${GITHUB_REF} \
+        -e SEMGREP_COMMIT=${{ github.event.pull_request.head.sha }} \
+        -e SEMGREP_PR_ID=${{github.event.pull_request.number}} \
+        returntocorp/semgrep:latest-nonroot \
+        semgrep ci
       shell: bash
-#        docker run --rm -v  "${PWD}:/src" \
-#        -e SEMGREP_APP_TOKEN=${{ inputs.semgrep-app-token }} \
-#        -e SEMGREP_REPO_NAME=${GITHUB_REPOSITORY} \
-#        -e SEMGREP_BRANCH=${GITHUB_REF} \
-#        -e SEMGREP_COMMIT=${{ github.event.pull_request.head.sha }} \
-#        -e SEMGREP_PR_ID=${{github.event.pull_request.number}} \
-#        returntocorp/semgrep:latest-nonroot \
-#        semgrep ci
-#      shell: bash


### PR DESCRIPTION
Description: This PR re-enable the semgrep checks for v2 version action path. Once merged, semgrep will resume scans in workflows pointing to these path.  This is the first task for resuming the semgrep across all the repos followed by breaking change PR for v3 and updated action path. 

Fixes:-
/static-analysis/action.yaml.

