### PR TITLE
fix(static-analysis): fixing diff aware scanning for semgrep

### DIFF
--- a/static-analysis/semgrep/README.md
+++ b/static-analysis/semgrep/README.md
@@ -20,7 +20,7 @@ Github Action that scans code changes being made and posts security findings in 
     # Default: true
 
     semgrep-app-token:
-    # SemGrep API token to be added to repo that allows to pull latest rule config from ruleboard in Semgrep UI
+    # SemGrep API token to pull the latest rule configuration from Semgrep's ruleboard
     #
     # Required: true
     # Default: ""

--- a/static-analysis/semgrep/README.md
+++ b/static-analysis/semgrep/README.md
@@ -4,7 +4,7 @@
 <!-- action-docs-description source="action.yaml" -->
 ## Description
 
-Github Action that scans code changes being made and posts security findings in form of comments on pull requests
+GitHub Action that scans code changes being made and posts security findings as comments on pull requests.
 <!-- action-docs-description source="action.yaml" -->
 
 <!-- action-docs-usage source="action.yaml" -->
@@ -14,13 +14,13 @@ Github Action that scans code changes being made and posts security findings in 
 - uses: @
   with:
     checkout-repo:
-    # Perform checkout as first step
+    # Perform checkout as the first step
     #
     # Required: false
     # Default: true
 
     semgrep-app-token:
-    # SemGrep API token to pull the latest rule configuration from Semgrep's ruleboard
+    # Semgrep API token to pull the latest rule configuration from the ruleboard in Semgrep UI.
     #
     # Required: true
     # Default: ""

--- a/static-analysis/semgrep/action.yaml
+++ b/static-analysis/semgrep/action.yaml
@@ -1,43 +1,28 @@
 name: Run static code analysis
-description: Github Action that scans code changes being made and posts security findings in form of comments on pull requests
+description: GitHub Action that scans code changes being made and posts security findings as comments on pull requests.
 inputs:
   checkout-repo:
-    description: Perform checkout as first step
+    description: Perform checkout as the first step
     required: false
     default: "true"
   semgrep-app-token:
     required: true
-    description: SemGrep API token to pull the latest rule configuration from Semgrep's ruleboard
-
+    description: Semgrep API token to pull the latest rule configuration from the ruleboard in Semgrep UI.
 runs:
   using: composite
   steps:
-    - name: Checkout
-      if: ${{ inputs.checkout-repo == 'true' }}
-      uses: actions/checkout@v4
+    - uses: actions/checkout@v4
       with:
-        fetch-depth: 2
+        fetch-depth: 2 # Fetch only the last two commits for efficient diff comparison
 
-    - name: Fetch Baseline Branch
-      run: |
-        set -e  # Fail on any errors
-        BASE_BRANCH=$(jq -r '.pull_request.base.ref // "main"' < "${GITHUB_EVENT_PATH}")
-        echo "Fetching base branch: $BASE_BRANCH"
-        git fetch origin $BASE_BRANCH:$BASE_BRANCH
-        echo "Base branch $BASE_BRANCH fetched successfully."
-      shell: bash
-
-    - name: Run Semgrep
-      run: |
-        BASE_BRANCH=$(jq -r '.pull_request.base.ref // "main"' < "${GITHUB_EVENT_PATH}")
-        echo "Running Semgrep with baseline branch: $BASE_BRANCH"
+    - run: |
         docker run --rm -v "${PWD}:/src" \
         -e SEMGREP_APP_TOKEN=${{ inputs.semgrep-app-token }} \
         -e SEMGREP_REPO_NAME=${GITHUB_REPOSITORY} \
         -e SEMGREP_BRANCH=${GITHUB_REF} \
         -e SEMGREP_COMMIT=${{ github.event.pull_request.head.sha }} \
         -e SEMGREP_PR_ID=${{ github.event.pull_request.number }} \
-        -e SEMGREP_BASELINE_REF=refs/heads/$BASE_BRANCH \
+        -e SEMGREP_BASELINE_REF='HEAD^' \
         semgrep/semgrep:latest-nonroot \
         semgrep ci
       shell: bash

--- a/static-analysis/semgrep/action.yaml
+++ b/static-analysis/semgrep/action.yaml
@@ -7,21 +7,37 @@ inputs:
     default: "true"
   semgrep-app-token:
     required: true
-    description: SemGrep API token to be added to repo that allows to pull latest rule config from ruleboard in Semgrep UI
+    description: SemGrep API token to pull the latest rule configuration from Semgrep's ruleboard
+
 runs:
   using: composite
   steps:
     - name: Checkout
-      if: ${{inputs.checkout-repo == 'true'}}
+      if: ${{ inputs.checkout-repo == 'true' }}
       uses: actions/checkout@v4
-    - run: echo "pausing checks"
+      with:
+        fetch-depth: 2
+
+    - name: Fetch Baseline Branch
+      run: |
+        set -e  # Fail on any errors
+        BASE_BRANCH=$(jq -r '.pull_request.base.ref // "main"' < "${GITHUB_EVENT_PATH}")
+        echo "Fetching base branch: $BASE_BRANCH"
+        git fetch origin $BASE_BRANCH:$BASE_BRANCH
+        echo "Base branch $BASE_BRANCH fetched successfully."
       shell: bash
-#        docker run --rm -v  "${PWD}:/src" \
-#        -e SEMGREP_APP_TOKEN=${{ inputs.semgrep-app-token }} \
-#        -e SEMGREP_REPO_NAME=${GITHUB_REPOSITORY} \
-#        -e SEMGREP_BRANCH=${GITHUB_REF} \
-#        -e SEMGREP_COMMIT=${{ github.event.pull_request.head.sha }} \
-#        -e SEMGREP_PR_ID=${{github.event.pull_request.number}} \
-#        returntocorp/semgrep:latest-nonroot \
-#        semgrep ci
-#      shell: bash
+
+    - name: Run Semgrep
+      run: |
+        BASE_BRANCH=$(jq -r '.pull_request.base.ref // "main"' < "${GITHUB_EVENT_PATH}")
+        echo "Running Semgrep with baseline branch: $BASE_BRANCH"
+        docker run --rm -v "${PWD}:/src" \
+        -e SEMGREP_APP_TOKEN=${{ inputs.semgrep-app-token }} \
+        -e SEMGREP_REPO_NAME=${GITHUB_REPOSITORY} \
+        -e SEMGREP_BRANCH=${GITHUB_REF} \
+        -e SEMGREP_COMMIT=${{ github.event.pull_request.head.sha }} \
+        -e SEMGREP_PR_ID=${{ github.event.pull_request.number }} \
+        -e SEMGREP_BASELINE_REF=refs/heads/$BASE_BRANCH \
+        semgrep/semgrep:latest-nonroot \
+        semgrep ci
+      shell: bash


### PR DESCRIPTION
Description:-

During the testing, we identified that the semgrep is not running the diff aware scans instead it is currently scanning the entire repo. As per the semgrep diff aware [documentation](https://semgrep.dev/docs/kb/semgrep-ci/trigger-diff-scans-env-var), our current setup might be failing because the diff-aware scanning requires a baseline reference to compare against the branch head. As the part of this fix,  we are dynamically determining the baseline branch for each repository for semgrep to compare. Creating this branch to test and confirm the fix. 

Fixes:-
/static-analysis/semgrep/action.yaml.