### PR TITLE
ci(semgrep): fixing semgrep failure in certain repos

### DIFF
--- a/static-analysis/README.md
+++ b/static-analysis/README.md
@@ -13,12 +13,6 @@ GitHub Action that scans code changes being made and posts security findings as 
 ```yaml
 - uses: @
   with:
-    checkout-repo:
-    # Perform checkout as the first step
-    #
-    # Required: false
-    # Default: true
-
     semgrep-app-token:
     # Semgrep API token to pull the latest rule configuration from the ruleboard in Semgrep UI.
     #

--- a/static-analysis/action.yaml
+++ b/static-analysis/action.yaml
@@ -1,28 +1,20 @@
 name: Run static code analysis
 description: GitHub Action that scans code changes being made and posts security findings as comments on pull requests.
 inputs:
-  checkout-repo:
-    description: Perform checkout as the first step
-    required: false
-    default: "true"
   semgrep-app-token:
     required: true
     description: Semgrep API token to pull the latest rule configuration from the ruleboard in Semgrep UI.
 runs:
   using: composite
   steps:
+    - uses: open-turo/action-setup-tools@v2
+      with:
+        python: 3.10.12
+
     - uses: actions/checkout@v4
       with:
-        fetch-depth: 2 # Fetch only the last two commits for efficient diff comparison
+        fetch-depth: 2
 
     - run: |
-        docker run --rm -v "${PWD}:/src" \
-        -e SEMGREP_APP_TOKEN=${{ inputs.semgrep-app-token }} \
-        -e SEMGREP_REPO_NAME=${GITHUB_REPOSITORY} \
-        -e SEMGREP_BRANCH=${GITHUB_REF} \
-        -e SEMGREP_COMMIT=${{ github.event.pull_request.head.sha }} \
-        -e SEMGREP_PR_ID=${{ github.event.pull_request.number }} \
-        -e SEMGREP_BASELINE_REF='HEAD^' \
-        semgrep/semgrep:latest-nonroot \
-        semgrep ci
+        SEMGREP_APP_TOKEN="${{ inputs.semgrep-app-token }}" pipx run --spec semgrep==1.101.0 semgrep ci
       shell: bash


### PR DESCRIPTION
**Description**

The fix install semgrep directly on the runner to avoid complexities related to passing baseline
variables via docker. In this mode, semgrep can fetch the required commits dynamically, making
shallow clones feasible.



**Changes**
/static-analysis/action.yaml

* ci(semgrep): fixing semgrep failure in certain repos

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
