### PR TITLE
chore(debug): add debug info to trace python/pipx behavior in security scan

### DIFF
--- a/static-analysis/action.yaml
+++ b/static-analysis/action.yaml
@@ -16,5 +16,9 @@ runs:
         fetch-depth: 2
 
     - run: |
+        echo "Debug PATH information:"
+        echo $PATH
+        python --version
+        which pipx || echo "pipx not found"
         SEMGREP_APP_TOKEN="${{ inputs.semgrep-app-token }}" pipx run --spec semgrep==1.101.0 semgrep ci
       shell: bash


### PR DESCRIPTION
# Summary
Adding debug output to help track down why our security scan step sometimes fails with `pipx: command not found`. 

Currently seeing inconsistent behavior where:
- Python 3.10.12 runs fail: pipx not found 
- Python 3.12.4 runs work: pipx runs fine

Added PATH/version logging to help determine if this is a PATH issue with different Python versions. Will use this info to decide if we need to make Python version selection more deterministic in our tooling.