### PR TITLE
SEC-3571: Fix credential passing errors in failing workflows

### DIFF
--- a/container-scan/action.yaml
+++ b/container-scan/action.yaml
@@ -83,12 +83,12 @@ runs:
         github-token: ${{ inputs.github-token }}
         image-platform: ${{ inputs.image-platform }}
         image-version: ${{ inputs.image-tag }}
-        build-args: ${{ inputs.build-args }}
-        secrets: |
+        build-args: |
           ARTIFACTORY_USERNAME=${{ inputs.artifactory-username }}
           ARTIFACTORY_AUTH_TOKEN=${{ inputs.artifactory-auth-token }}
           MAX_MIND_LICENSE_KEY=${{ inputs.MAX_MIND_LICENSE_KEY }}
-          VFUNCTION_FILE_NAME=${{ inputs.vfunction-file }}
+          ${{ inputs.build-args }}
+        secrets: ${{ inputs.secrets }}
     - name: Determine Image Name
       id: set_image_name
       run: |


### PR DESCRIPTION
**Description**

## Description
Updates the container scan action to pass Artifactory and MaxMind credentials as build args instead of secrets, to match how they are consumed in the Dockerfile using ARG instructions.

## Changes
- Moves `ARTIFACTORY_USERNAME`, `ARTIFACTORY_AUTH_TOKEN`, and `MAX_MIND_LICENSE_KEY` from secrets to build args
- Removes unused `VFUNCTION_FILE_NAME` secret
- Preserves ability to pass additional secrets via `inputs.secrets`

## Testing
- [ ] Tested with payments-msvc build
- [ ] Verified credentials are properly passed to gradle build
- [ ] Security scan completes successfully

## Impact
This change affects how credentials are passed during Docker builds but maintains the same level of security since the values are still sourced from GitHub secrets.

Fixes [#SEC-3571](https://team-turo.atlassian.net//browse/SEC-3571)

**Changes**

* fix: move Artifactory credentials to build args in container scan

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)