### PR TITLE
Fix container scan failing with invalid tag format by using github.sha directly in build s

### DIFF
--- a/container-scan/action.yaml
+++ b/container-scan/action.yaml
@@ -82,7 +82,7 @@ runs:
         dockerhub-password: ${{ inputs.dockerhub-password }}
         github-token: ${{ inputs.github-token }}
         image-platform: ${{ inputs.image-platform }}
-        image-version: ${{ inputs.image-tag }}
+        image-version: ${{ github.sha }}
         build-args: |
           ARTIFACTORY_USERNAME=${{ inputs.artifactory-username }}
           ARTIFACTORY_AUTH_TOKEN=${{ inputs.artifactory-auth-token }}


### PR DESCRIPTION
**Description**

Fixed container scan failures that were occurring due to invalid tag format. The docker build step was using an empty tag value from input parameters, causing the build to fail with:

```bash
ERROR: invalid tag "/<image name>:": invalid reference format
```


## Problem
While the reusable workflow had a default value for `image-tag`, the build step needed to use the commit SHA directly to ensure consistent tagging. The error occurred because the tag was being constructed without a value after the colon.

## Solution
Modified the container-scan action to use `github.sha` directly for the docker build step's image version, while maintaining the use of `inputs.image-tag` for the scan step. This ensures consistent tagging throughout the build and scan process.

## Testing
- [ ] Verified container builds complete successfully with proper tag
- [ ] Verified container scans run with matching tag
- [ ] Confirmed no changes needed to reusable workflow or docker-build action


**Changes**

* fix: use github.sha directly for docker build image version

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)