### PR TITLE
fix: use action-setup-tools to set up v3.13.2

### DIFF
--- a/static-analysis/action.yaml
+++ b/static-analysis/action.yaml
@@ -9,7 +9,7 @@ runs:
   steps:
     - uses: open-turo/action-setup-tools@v2
       with:
-        python: 3.10.12
+        python: 3.13.2
 
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION

**Description**





**Changes**

* ci: use action-setup-tools to set up v3.13.2

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)