### PR TITLE
feat(adding semgrep secrets scan): adding secret scanning capabilities

### DIFF
--- a/static-analysis/README.md
+++ b/static-analysis/README.md
@@ -18,6 +18,12 @@ GitHub Action that scans code changes being made and posts security findings as 
     #
     # Required: true
     # Default: ""
+
+    config:
+    # Optional Semgrep config name (e.g., p/secrets)
+    #
+    # Required: false
+    # Default: ""
 ```
 <!-- action-docs-usage source="action.yaml" -->
 

--- a/static-analysis/README.md
+++ b/static-analysis/README.md
@@ -19,8 +19,8 @@ GitHub Action that scans code changes being made and posts security findings as 
     # Required: true
     # Default: ""
 
-    config:
-    # Optional Semgrep config name (e.g., p/secrets)
+    secrets-ony:
+    # If 'true', run 'semgrep ci --secrets' instead of full scan
     #
     # Required: false
     # Default: ""

--- a/static-analysis/action.yaml
+++ b/static-analysis/action.yaml
@@ -4,10 +4,10 @@ inputs:
   semgrep-app-token:
     required: true
     description: Semgrep API token to pull the latest rule configuration from the ruleboard in Semgrep UI.
-  config:
+  secrets-ony:
     required: false
     default: ""
-    description: Optional Semgrep config name (e.g., p/secrets)
+    description: "If 'true', run 'semgrep ci --secrets' instead of full scan"
 runs:
   using: composite
   steps:
@@ -24,10 +24,12 @@ runs:
         echo $PATH
         python --version
         which pipx || echo "pipx not found"
-        if [ -n "${{ inputs.config }}" ]; then
+        if [ "${{ inputs.secrets-only }}" = "true" ]; then
+          echo "Running Semgrep secrets-only scan"
           SEMGREP_APP_TOKEN="${{ inputs.semgrep-app-token }}" \
-            pipx run --spec semgrep==1.101.0 semgrep ci --config "${{ inputs.config }}"
+            pipx run --spec semgrep==1.101.0 semgrep ci --secrets
         else
+          echo "Running full Semgrep CI scan"
           SEMGREP_APP_TOKEN="${{ inputs.semgrep-app-token }}" \
             pipx run --spec semgrep==1.101.0 semgrep ci
         fi

--- a/static-analysis/action.yaml
+++ b/static-analysis/action.yaml
@@ -4,6 +4,10 @@ inputs:
   semgrep-app-token:
     required: true
     description: Semgrep API token to pull the latest rule configuration from the ruleboard in Semgrep UI.
+  config:
+    required: false
+    default: ""
+    description: Optional Semgrep config name (e.g., p/secrets)
 runs:
   using: composite
   steps:
@@ -20,5 +24,11 @@ runs:
         echo $PATH
         python --version
         which pipx || echo "pipx not found"
-        SEMGREP_APP_TOKEN="${{ inputs.semgrep-app-token }}" pipx run --spec semgrep==1.101.0 semgrep ci
+        if [ -n "${{ inputs.config }}" ]; then
+          SEMGREP_APP_TOKEN="${{ inputs.semgrep-app-token }}" \
+            pipx run --spec semgrep==1.101.0 semgrep ci --config "${{ inputs.config }}"
+        else
+          SEMGREP_APP_TOKEN="${{ inputs.semgrep-app-token }}" \
+            pipx run --spec semgrep==1.101.0 semgrep ci
+        fi
       shell: bash


### PR DESCRIPTION
### What’s changing
Introduce a new optional `config` input in action.yml.
When provided, the action runs `semgrep ci --config <config>`; otherwise defaults to `semgrep ci`.

### Why
We need to run both full CI scans on pull requests and weekly secrets-only scans from the same action.

### Testing
This branch will be referenced by our reusable workflow’s schedule job to verify the new behavior.