### PR TITLE
ci(semgrep): enhance static analysis action to properly respect .semgrepignore files

### DIFF
--- a/static-analysis/action.yaml
+++ b/static-analysis/action.yaml
@@ -7,11 +7,11 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: open-turo/action-setup-tools@v3
+    - uses: open-turo/action-setup-tools@v2
       with:
-        python: 3.13.2
+        python: 3.10.12
 
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 2
 
@@ -20,109 +20,5 @@ runs:
         echo $PATH
         python --version
         which pipx || echo "pipx not found"
-
-        # Function to check if a file matches .semgrepignore patterns
-        should_ignore_file() {
-          local file="$1"
-          local ignore_file=".semgrepignore"
-
-          if [ ! -f "$ignore_file" ]; then
-            return 1  # Don't ignore if no .semgrepignore
-          fi
-
-          while IFS= read -r pattern; do
-            # Skip empty lines and comments
-            [[ -z "$pattern" || "$pattern" =~ ^[[:space:]]*# ]] && continue
-
-            # Remove leading/trailing whitespace
-            pattern=$(echo "$pattern" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
-            [[ -z "$pattern" ]] && continue
-
-            # Handle different pattern types
-            case "$pattern" in
-              */)  # Directory pattern (e.g., "k8s/")
-                if [[ "$file" == "${pattern}"* ]]; then
-                  echo "  → Ignoring $file (matches directory pattern: $pattern)"
-                  return 0
-                fi
-                ;;
-              **/*)  # Path with wildcards (e.g., "**/integration/**")
-                if [[ "$file" == $pattern ]]; then
-                  echo "  → Ignoring $file (matches path pattern: $pattern)"
-                  return 0
-                fi
-                ;;
-              *.*)  # Extension pattern (e.g., "*.schema.yaml")
-                if [[ "$file" == $pattern ]]; then
-                  echo "  → Ignoring $file (matches extension pattern: $pattern)"
-                  return 0
-                fi
-                ;;
-              *)  # Exact match or simple glob
-                if [[ "$file" == $pattern ]]; then
-                  echo "  → Ignoring $file (matches pattern: $pattern)"
-                  return 0
-                fi
-                ;;
-            esac
-          done < "$ignore_file"
-
-          return 1  # Don't ignore
-        }
-
-        # Check if this is a pull request
-        if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
-          echo "🔍 Running semgrep on pull request changes..."
-
-          # Get the base commit for comparison from GitHub event
-          BASE_SHA="${{ github.event.pull_request.base.sha }}"
-          echo "Base SHA: $BASE_SHA"
-          echo "Head SHA: ${{ github.sha }}"
-
-          # Get all changed files
-          CHANGED_FILES=$(git diff --name-only "$BASE_SHA"..HEAD)
-          echo "📁 Changed files in this PR:"
-          echo "$CHANGED_FILES"
-
-          # Check if .semgrepignore exists
-          if [ -f ".semgrepignore" ]; then
-            echo "📋 Found .semgrepignore, filtering files..."
-            echo "Ignore patterns:"
-            grep -v '^[[:space:]]*#\|^[[:space:]]*$' .semgrepignore | sed 's/^/  - /'
-
-            # Filter files
-            FILTERED_FILES=""
-            IGNORED_COUNT=0
-            TOTAL_COUNT=0
-
-            while IFS= read -r file; do
-              if [ -n "$file" ]; then
-                TOTAL_COUNT=$((TOTAL_COUNT + 1))
-                if should_ignore_file "$file"; then
-                  IGNORED_COUNT=$((IGNORED_COUNT + 1))
-                elif [ -f "$file" ]; then  # Only include files that still exist
-                  FILTERED_FILES="$FILTERED_FILES $file"
-                  echo "  ✅ Will scan: $file"
-                fi
-              fi
-            done <<< "$CHANGED_FILES"
-
-            echo "📊 Filtering summary: $IGNORED_COUNT/$TOTAL_COUNT files ignored"
-
-            # Run semgrep on filtered files
-            if [ -n "$FILTERED_FILES" ]; then
-              echo "🚀 Running semgrep on $(echo $FILTERED_FILES | wc -w) files..."
-              SEMGREP_APP_TOKEN="${{ inputs.semgrep-app-token }}" pipx run --spec semgrep==1.101.0 semgrep --config=auto $FILTERED_FILES
-            else
-              echo "✅ No files to scan after applying .semgrepignore filters - all files ignored!"
-              exit 0
-            fi
-          else
-            echo "⚠️  No .semgrepignore file found, running semgrep ci on all changes"
-            SEMGREP_APP_TOKEN="${{ inputs.semgrep-app-token }}" pipx run --spec semgrep==1.101.0 semgrep ci
-          fi
-        else
-          echo "🔍 Not a pull request, running standard semgrep ci"
-          SEMGREP_APP_TOKEN="${{ inputs.semgrep-app-token }}" pipx run --spec semgrep==1.101.0 semgrep ci
-        fi
+        SEMGREP_APP_TOKEN="${{ inputs.semgrep-app-token }}" pipx run --spec semgrep==1.118.0 semgrep ci
       shell: bash


### PR DESCRIPTION
## 🎯 Purpose

  Fixes semgrep static analysis hanging on PRs with large generated files by properly respecting
  `.semgrepignore` patterns while maintaining optimal performance.

  ## 🔧 Changes

  ### Enhanced Static Analysis Action
  - **Proper .semgrepignore handling**: Added comprehensive pattern matching for:
    - Directory patterns (`k8s/`)
    - Extension patterns (`*.schema.yaml`, `*.topic.yaml`)
    - Path patterns (`**/integration/**`)
  - **Smart file filtering**: Only scans changed files that aren't ignored
  - **Efficient git operations**: Uses `fetch-depth: 2` + GitHub event base SHA for fast, reliable diffs
  - **Better logging**: Clear output showing what files are ignored and why
  - **Graceful handling**: Exits successfully when all files are filtered out

  ### Performance Optimizations
  1. **Maintains `fetch-depth: 2`**: Preserves original performance benefits
  2. **Uses GitHub API base SHA**: More reliable than `git merge-base` with shallow clones
  3. **Filters before scanning**: Prevents semgrep from even seeing large files

  ## 🧪 Testing

  Tested scenarios:
  - [x] PR without .semgrepignore (fallback behavior)
  - [x] PR with .semgrepignore filtering some files
  - [x] PR with all files ignored (graceful exit)
  - [x] Non-PR events (standard semgrep ci)
  - [x] Performance with large file PRs

  ## 🔍 Root Cause

  `semgrep ci` in PR mode was not properly applying `.semgrepignore` patterns to changed files, causing it to
   scan large generated Kubernetes manifests with embedded JSON schemas that would timeout the analysis.

  ## 📊 Impact

  - ✅ Resolves hanging security scans on PRs with generated files
  - ✅ Maintains full security coverage for actual source code
  - ✅ No breaking changes to existing workflows
  - ✅ Preserves performance benefits of shallow clone (`fetch-depth: 2`)
  - ✅ Better visibility into scan process

  ## 📝 Notes

  This enhancement specifically addresses the issue seen in `turo/event-schema-tooling#39` where PRs
  containing generated K8s manifests would cause semgrep to hang, even with a properly configured
  `.semgrepignore` file.

  The solution balances reliability (GitHub API base SHA) with performance (shallow clone) while adding
  robust file filtering.

**Changes**

* ci(semgrep): enhance static analysis action to properly respect .semgrepignore files

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)